### PR TITLE
Feat/#6/optimistic lock

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,8 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
-//	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/com/driply/payments/annotation/Retry.java
+++ b/src/main/java/com/driply/payments/annotation/Retry.java
@@ -1,0 +1,12 @@
+package com.driply.payments.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Retry {
+	int value() default 3;
+}

--- a/src/main/java/com/driply/payments/aop/RetryAspect.java
+++ b/src/main/java/com/driply/payments/aop/RetryAspect.java
@@ -1,0 +1,31 @@
+package com.driply.payments.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import com.driply.payments.annotation.Retry;
+
+@Aspect
+@Component
+public class RetryAspect {
+
+	@Around("@annotation(retry)")
+	public Object doRetry(ProceedingJoinPoint joinPoint, Retry retry) throws Throwable {
+		int maxRetry = retry.value();
+		Exception exceptionHolder = null;
+
+		for (int attempt = 1; attempt <= maxRetry; attempt++) {
+			try {
+				return joinPoint.proceed();
+			} catch (Exception e) {
+				exceptionHolder = e;
+				if (attempt == maxRetry) {
+					throw exceptionHolder;
+				}
+			}
+		}
+		throw new IllegalStateException("재시도 로직에서 예기치 않은 종료");
+	}
+}

--- a/src/main/java/com/driply/payments/common/BaseEntity.java
+++ b/src/main/java/com/driply/payments/common/BaseEntity.java
@@ -1,13 +1,14 @@
 package com.driply.payments.common;
 
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-
-import java.time.LocalDateTime;
 
 @Getter
 @SuperBuilder

--- a/src/main/java/com/driply/payments/common/JsonUtil.java
+++ b/src/main/java/com/driply/payments/common/JsonUtil.java
@@ -3,6 +3,7 @@ package com.driply.payments.common;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/driply/payments/payment/converter/PaymentRequestConverter.java
+++ b/src/main/java/com/driply/payments/payment/converter/PaymentRequestConverter.java
@@ -1,8 +1,8 @@
 package com.driply.payments.payment.converter;
 
-import com.driply.payments.payment.dto.PaymentRequestDTO;
-
 import java.util.Map;
+
+import com.driply.payments.payment.dto.PaymentRequestDTO;
 
 public interface PaymentRequestConverter<T extends PaymentRequestDTO> {
     /**

--- a/src/main/java/com/driply/payments/payment/converter/PaymentRequestConverterFactory.java
+++ b/src/main/java/com/driply/payments/payment/converter/PaymentRequestConverterFactory.java
@@ -1,11 +1,13 @@
 package com.driply.payments.payment.converter;
 
-import com.driply.payments.payment.dto.PaymentRequestDTO;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
-
 import java.util.List;
 import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.driply.payments.payment.dto.PaymentRequestDTO;
+
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/driply/payments/payment/converter/TossPaymentsRequestConverter.java
+++ b/src/main/java/com/driply/payments/payment/converter/TossPaymentsRequestConverter.java
@@ -1,11 +1,12 @@
 package com.driply.payments.payment.converter;
 
-import com.driply.payments.payment.dto.TossPaymentRequestDTO;
-import com.driply.payments.payment.entity.PGType;
-import org.springframework.stereotype.Component;
-
 import java.math.BigDecimal;
 import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.driply.payments.payment.dto.TossPaymentRequestDTO;
+import com.driply.payments.payment.entity.PGType;
 
 @Component
 public class TossPaymentsRequestConverter implements PaymentRequestConverter<TossPaymentRequestDTO> {

--- a/src/main/java/com/driply/payments/payment/dto/PaymentRequestDTO.java
+++ b/src/main/java/com/driply/payments/payment/dto/PaymentRequestDTO.java
@@ -1,12 +1,12 @@
 package com.driply.payments.payment.dto;
 
+import java.math.BigDecimal;
+import java.util.Map;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-
-import java.math.BigDecimal;
-import java.util.Map;
 
 @Data
 @SuperBuilder

--- a/src/main/java/com/driply/payments/payment/dto/PaymentResponseDTO.java
+++ b/src/main/java/com/driply/payments/payment/dto/PaymentResponseDTO.java
@@ -1,6 +1,7 @@
 package com.driply.payments.payment.dto;
 
 import com.driply.payments.payment.entity.PaymentStatus;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/com/driply/payments/payment/dto/TossPaymentRequestDTO.java
+++ b/src/main/java/com/driply/payments/payment/dto/TossPaymentRequestDTO.java
@@ -1,11 +1,11 @@
 package com.driply.payments.payment.dto;
 
+import java.util.Map;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-
-import java.util.Map;
 
 @Data
 @SuperBuilder

--- a/src/main/java/com/driply/payments/payment/entity/Payment.java
+++ b/src/main/java/com/driply/payments/payment/entity/Payment.java
@@ -61,6 +61,9 @@ public class Payment extends BaseEntity {
     @Column(columnDefinition = "jsonb")
     private Map<String, Object> extraData;
 
+    @Version
+    private Long version;
+
     public void approve(String paymentMethod) {
                 if (this.status != PaymentStatus.PENDING) {
                     throw new IllegalStateException("이미 처리된 결제입니다.");

--- a/src/main/java/com/driply/payments/payment/entity/Payment.java
+++ b/src/main/java/com/driply/payments/payment/entity/Payment.java
@@ -1,6 +1,13 @@
 package com.driply.payments.payment.entity;
 
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+import org.hibernate.annotations.Type;
+
 import com.driply.payments.common.BaseEntity;
+
 import io.hypersistence.utils.hibernate.type.json.JsonBinaryType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -10,15 +17,11 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import org.hibernate.annotations.Type;
-
-import java.math.BigDecimal;
-import java.time.OffsetDateTime;
-import java.util.Map;
 
 @Entity
 @Getter

--- a/src/main/java/com/driply/payments/payment/entity/PaymentError.java
+++ b/src/main/java/com/driply/payments/payment/entity/PaymentError.java
@@ -1,9 +1,9 @@
 package com.driply.payments.payment.entity;
 
+import java.time.LocalDateTime;
+
 import lombok.Getter;
 import lombok.Setter;
-
-import java.time.LocalDateTime;
 
 @Getter
 @Setter

--- a/src/main/java/com/driply/payments/payment/entity/PaymentStatus.java
+++ b/src/main/java/com/driply/payments/payment/entity/PaymentStatus.java
@@ -4,6 +4,6 @@ public enum PaymentStatus {
     PAID,
     PENDING,
     FAILED,
-    CANCELLED,
+    CANCELED,
     REFUNDED
 }

--- a/src/main/java/com/driply/payments/payment/exception/PaymentException.java
+++ b/src/main/java/com/driply/payments/payment/exception/PaymentException.java
@@ -1,8 +1,8 @@
 package com.driply.payments.payment.exception;
 
-import com.driply.payments.payment.entity.PGType;
-
 import java.math.BigDecimal;
+
+import com.driply.payments.payment.entity.PGType;
 
 public class PaymentException extends Exception {
     private final BigDecimal amount; // 결제 금액

--- a/src/main/java/com/driply/payments/payment/gateway/PaymentGateway.java
+++ b/src/main/java/com/driply/payments/payment/gateway/PaymentGateway.java
@@ -1,11 +1,11 @@
 package com.driply.payments.payment.gateway;
 
+import java.util.Map;
+
 import com.driply.payments.payment.dto.PaymentRequestDTO;
 import com.driply.payments.payment.entity.PaymentError;
 import com.driply.payments.payment.entity.PaymentStatus;
 import com.driply.payments.payment.exception.PaymentException;
-
-import java.util.Map;
 
 public interface PaymentGateway {
     // 결제 실행

--- a/src/main/java/com/driply/payments/payment/gateway/PaymentGatewayFactory.java
+++ b/src/main/java/com/driply/payments/payment/gateway/PaymentGatewayFactory.java
@@ -1,9 +1,10 @@
 package com.driply.payments.payment.gateway;
 
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
-import java.util.List;
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/driply/payments/payment/gateway/TossPaymentsGateway.java
+++ b/src/main/java/com/driply/payments/payment/gateway/TossPaymentsGateway.java
@@ -1,20 +1,5 @@
 package com.driply.payments.payment.gateway;
 
-import com.driply.payments.common.JsonUtil;
-import com.driply.payments.payment.dto.PaymentRequestDTO;
-import com.driply.payments.payment.entity.PGType;
-import com.driply.payments.payment.entity.PaymentError;
-import com.driply.payments.payment.entity.PaymentStatus;
-import com.driply.payments.payment.exception.PaymentException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -28,6 +13,23 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.driply.payments.common.JsonUtil;
+import com.driply.payments.payment.dto.PaymentRequestDTO;
+import com.driply.payments.payment.entity.PGType;
+import com.driply.payments.payment.entity.PaymentError;
+import com.driply.payments.payment.entity.PaymentStatus;
+import com.driply.payments.payment.exception.PaymentException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/driply/payments/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/driply/payments/payment/repository/PaymentRepository.java
@@ -1,7 +1,8 @@
 package com.driply.payments.payment.repository;
 
-import com.driply.payments.payment.entity.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.driply.payments.payment.entity.Payment;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #6 

## 📝작업 내용

> 낙관적 락 구현을 위해 `Payment` 엔티티에 `version` 필드를 추가했습니다.
> `OptimisticLockException` 예외 발생 시 재시도 로직 작성했습니다. AOP 적용하여 재사용할 수 있도록 구현했습니다. 

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

## 체크리스트
