### PR TITLE
fix: 보호 자원 범위 재설정

### DIFF
--- a/src/main/java/com/driply/payments/config/IpWhitelistFilter.java
+++ b/src/main/java/com/driply/payments/config/IpWhitelistFilter.java
@@ -49,8 +49,6 @@ public class IpWhitelistFilter implements WebFilter {
 	);
 
 	private static final Set<String> PROTECTED_PATHS = Set.of(
-		"/api/v1/payment/confirm/payment",
-		"/api/v1/payment/confirm/widget",
 		"/api/v1/payment/callback"
 	);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #23 

## 📝작업 내용

> 보호 자원으로 포함되지 말아야할 두 엔드포인트("/api/v1/payment/confirm/payment", "/api/v1/payment/confirm/widget")를 PROTECTED_PATHS 목록에서 제거해주었습니다. 
> 두 엔드포인트는 시스템에서 결제 승인 요청을 보내기 전, 클라이언트 측에서 꼭 호출되어야 하는 엔드포인트입니다. 그래서 어디서든 접근이 가능해야 하는 엔드포인트인데 보호 자원에 포함되어 있었습니다. 로컬ip 주소를 화이트리스트로 등록을 해둬서 로컬에서 작업하는 동안에는 잘못된 것을 모르고 있었다가 이번에 배포 작업을 진행하면서 알게되어 급하게 수정 작업 진행했습니다.

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

## 체크리스트
