### PR TITLE
feat: add environments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,9 @@ services:
     image: apache/kafka:3.9.1
     ports:
       - "9092:9092"
+    environment:
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
     volumes:
       - kafka_data:/var/lib/kafka/data
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #37 

## 📝작업 내용

> 기존 docker-compose.yml 파일에는 별도의 환경변수 설정이 없었는데,
KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092 값을 추가해줬습니다. 
> 위 값을 설정하지 않으면 기본적으로 apach/kafka 이미지는 localhost:9092 값을 사용하게 되면서, 컨테이너 내부에서 localhost:9092 로 연결하지 못하면서 카프카가 컨슈머 로직이 작동하지 않습니다. (실제 카프카는 다른 컨테이너, 동일 네트워크에 존재함. DNS 네임을 통해 접근할 수는 있지만 localhost로 설정하면 컨테이너 내부에서 찾기 때문에 찾을 수 없음)

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

## 체크리스트
