### PR TITLE
Hotfix/#37/add kafka env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,9 @@ services:
     image: apache/kafka:3.9.1
     ports:
       - "9092:9092"
+    environment:
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
     volumes:
       - kafka_data:/var/lib/kafka/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,8 @@ services:
     ports:
       - "9092:9092"
     environment:
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_LISTENERS: "PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093"
+      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://kafka:9092"
     volumes:
       - kafka_data:/var/lib/kafka/data
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,8 @@ spring:
   profiles:
     active: dev
     include: secret
+  kafka:
+    bootstrap-servers: kafka:9092
   cloud:
     stream:
       binders:


### PR DESCRIPTION
## #️⃣연관된 이슈

#37 

## 📝작업 내용

> KAFKA_LISTENERS 환경변수에 CONTROLLER://0.0.0.0:9093 를 추가해줬습니다. 해당 주소를 리스너로 지정해줘야 KRAFT 모드로 컨테이너가 실행된다고 합니다. KRAFT 모드가 비활성화 되어있으면 zookeeper 를 연결해줘야 정상 동작합니다.

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

## 체크리스트
